### PR TITLE
correctly implements access to Pimple services, via the public functions

### DIFF
--- a/src/Simplarity/Pimple.php
+++ b/src/Simplarity/Pimple.php
@@ -33,12 +33,12 @@ namespace Simplarity;
  */
 class Pimple implements \ArrayAccess
 {
-    protected $values = array();
-    protected $factories;
-    protected $protected;
-    protected $frozen = array();
-    protected $raw = array();
-    protected $keys = array();
+    private $values = array();
+    private $factories;
+    private $protected;
+    private $frozen = array();
+    private $raw = array();
+    private $keys = array();
 
     /**
      * Instantiate the container.
@@ -66,8 +66,9 @@ class Pimple implements \ArrayAccess
      * as function names (strings) are callable (creating a function with
      * the same name as an existing parameter would break your container).
      *
-     * @param  string            $id    The unique identifier for the parameter or object
-     * @param  mixed             $value The value of the parameter or a closure to define an object
+     * @param string $id    The unique identifier for the parameter or object
+     * @param mixed  $value The value of the parameter or a closure to define an object
+     *
      * @throws \RuntimeException Prevent override of a frozen service
      */
     public function offsetSet($id, $value)
@@ -156,7 +157,7 @@ class Pimple implements \ArrayAccess
      */
     public function factory($callable)
     {
-        if (!is_object($callable) || !method_exists($callable, '__invoke')) {
+        if (!method_exists($callable, '__invoke')) {
             throw new \InvalidArgumentException('Service definition is not a Closure or invokable object.');
         }
 
@@ -178,7 +179,7 @@ class Pimple implements \ArrayAccess
      */
     public function protect($callable)
     {
-        if (!is_object($callable) || !method_exists($callable, '__invoke')) {
+        if (!method_exists($callable, '__invoke')) {
             throw new \InvalidArgumentException('Callable is not a Closure or invokable object.');
         }
 
@@ -260,5 +261,4 @@ class Pimple implements \ArrayAccess
         return array_keys($this->values);
     }
 
-    
 }

--- a/src/Simplarity/Plugin.php
+++ b/src/Simplarity/Plugin.php
@@ -5,7 +5,7 @@ class Plugin extends Pimple {
 
     public function run(){
         foreach( $this->keys() as $key ){ // Loop on contents
-            $content = $this->raw( $key );
+            $content = $this->offsetGet( $key );
 
             if( is_object( $content ) ){
                 $reflection = new \ReflectionClass( $content );

--- a/src/Simplarity/Plugin.php
+++ b/src/Simplarity/Plugin.php
@@ -2,11 +2,11 @@
 namespace Simplarity;
 
 class Plugin extends Pimple {
-    
-    public function run(){ 
-        foreach( $this->values as $key => $content ){ // Loop on contents
-            $content = $this[$key];
-            
+
+    public function run(){
+        foreach( $this->keys() as $key ){ // Loop on contents
+            $content = $this->raw( $key );
+
             if( is_object( $content ) ){
                 $reflection = new \ReflectionClass( $content );
                 if( $reflection->hasMethod( 'run' ) ){


### PR DESCRIPTION
Instead of telling people to change [third party code](https://www.smashingmagazine.com/2015/05/how-to-use-autoloading-and-a-plugin-container-in-wordpress-plugins/#comment-1287329)&mdash;which is what I did after initially reading your very good article, I think we should encourage them to use the API libraries offer.

This pull request correctly accesses Pimple without tampering with the original code. (I did mimick that you changed the class name and removed the register method&mdash;as this is not what I wanted to highlight. 

Instead of changing the class variables from `private` to `protected`, this PR uses the correct exposed API methods `keys()` and `offsetGet()` to access Pimple. I would greatly appreciate if this was merged and possibly even if the article was updated to reflect the "correct" way of using Pimple.
